### PR TITLE
shop enrollments found via IVL are treated as such

### DIFF
--- a/lib/api/v1/mobile/enrollment/base_enrollment.rb
+++ b/lib/api/v1/mobile/enrollment/base_enrollment.rb
@@ -32,7 +32,7 @@ module Api
         end
 
         def self.excluding_invisible enrollments
-          enrollments.reject{ |e| e.external_enrollment || ['void', 'coverage_canceled'].include?(e.aasm_state) || e.submitted_at.nil? }.sort_by(&:submitted_at) 
+          enrollments.reject{ |e| e.external_enrollment || ['void', 'coverage_canceled'].include?(e.aasm_state)}.sort_by{|e| e.submitted_at || 100.years.ago }
         end
 
         def self.is_enrolled_or_terminated enrollment_representation

--- a/lib/api/v1/mobile/enrollment/base_enrollment.rb
+++ b/lib/api/v1/mobile/enrollment/base_enrollment.rb
@@ -149,6 +149,15 @@ module Api
           response[enrollment.coverage_kind.to_sym] &&
             response[enrollment.coverage_kind.to_sym][:status] == EnrollmentConstants::ENROLLED
         end
+
+        def __specific_enrollment_fields enrollment, apply_ivl_rules=false
+          if enrollment.is_shop?
+            EmployeeEnrollment.specific_enrollment_fields enrollment, apply_ivl_rules
+          else
+            IndividualEnrollment.specific_enrollment_fields enrollment, apply_ivl_rules
+          end
+        end
+    
       end
 
       module EnrollmentConstants

--- a/lib/api/v1/mobile/enrollment/base_enrollment.rb
+++ b/lib/api/v1/mobile/enrollment/base_enrollment.rb
@@ -32,7 +32,7 @@ module Api
         end
 
         def self.excluding_invisible enrollments
-          enrollments.reject{ |e| e.external_enrollment || ['void', 'coverage_canceled'].include?(e.aasm_state)}.sort_by{|e| e.submitted_at || 100.years.ago }
+          enrollments.reject{ |e| e.external_enrollment || ['void', 'coverage_canceled'].include?(e.aasm_state)}.sort_by{|e| e.submitted_at.to_i }
         end
 
         def self.is_enrolled_or_terminated enrollment_representation

--- a/lib/api/v1/mobile/enrollment/employee_enrollment.rb
+++ b/lib/api/v1/mobile/enrollment/employee_enrollment.rb
@@ -47,12 +47,7 @@ module Api
           add_enrollments.call
         end
 
-        #
-        # Protected
-        #
-        protected
-
-        def __specific_enrollment_fields enrollment, apply_ivl_rules=false
+        def self.specific_enrollment_fields enrollment, apply_ivl_rules=false
           begin
             add_contributions = ->(enrollment_attributes) {
               if apply_ivl_rules


### PR DESCRIPTION
Turns out sometimes there are enrollments found via the Family::Households that are SHOP enrollments despite the fact that there appears to be no benefit group assignment for that employee in the employer records. Weird! Anyway, we're just going to handle it the same way enroll web front end does.